### PR TITLE
feat: Adds annotation support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Usage
 
 Assuming you have a class like
 
-::
+.. code-block:: python
 
     class Book:
         def __init__(self, _id, name):
@@ -65,11 +65,12 @@ Assuming you have a class like
 Declare schemes
 ---------------
 You can declare a schema for serialization like
-::
+
+.. code-block:: python
 
     from calamus import fields
     from calamus.schema import JsonLDSchema
-    
+
     schema = fields.Namespace("http://schema.org/")
 
     class BookSchema(JsonLDSchema):
@@ -90,7 +91,7 @@ Serializing objects ("Dumping")
 
 You can now easily serialize python classes to JSON-LD
 
-::
+.. code-block:: python
 
     book = Book(_id="http://example.com/books/1", name="Ilias")
     jsonld_dict = BookSchema().dump(book)
@@ -108,7 +109,7 @@ Deserializing objects ("Loading")
 
 You can also easily deserialize JSON-LD to python objects
 
-::
+.. code-block:: python
 
     data = {
         "@id": "http://example.com/books/1",
@@ -204,6 +205,39 @@ The function validate_properties has 3 arguments: ``data``, ``ontology`` and ``r
 ``ontology`` is a string pointing to the OWL ontology's location (path or URI).
 
 ``return_valid_data`` is an optional argument with the default value ``False``. Default behavior is to return dictionary with valid and invalid properties. Setting this to True returns the JSON-LD with only validated properties.
+
+Annotations
+-----------
+
+Classes can also be annotated directly with schema information, removing the need to have a separate schema. This
+can be done by setting the ``metaclass`` of the model to ``JsonLDAnnotation``.
+
+.. code-block:: python
+
+    import datetime.datetime as dt
+
+    from calamus import JsonLDAnnotation
+    import calamus.fields as fields
+
+    schema = fields.Namespace("http://schema.org/")
+
+    class User(metaclass=JsonLDAnnotation):
+        _id = fields.Id()
+        birth_date = fields.Date(schema.birthDate, default=dt.now)
+        name = fields.String(schema.name, default=lambda: "John")
+
+        class Meta:
+            rdf_type = schema.Person
+
+    user = User()
+
+    # dumping
+    User.schema().dump(user)
+    # or
+    user.dump()
+
+    # loading
+    u = User.schema().load({"_id": "http://example.com/user/1", "name": "Bill", "birth_date": "1970-01-01 00:00"})
 
 Support
 =======

--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -302,7 +302,7 @@ class Nested(_JsonLDField, fields.Nested):
         nested = []
 
         for n in self.nested:
-            if issubclass(n, JsonLDSchema):
+            if isinstance(n, str) or issubclass(n, JsonLDSchema):
                 nested.append(n)
             else:
                 if hasattr(n, "__calamus_schema__"):

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -90,6 +90,7 @@ LD
 Matlab
 memoization
 metadata
+metaclass
 microservices
 middleware
 minikube

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for deserialization from python dicts."""
+
+import calamus.fields as fields
+from calamus.schema import JsonLDAnnotation
+
+
+def test_annotation():
+    """Test annotation support."""
+    schema = fields.Namespace("http://schema.org/")
+
+    class Book(metaclass=JsonLDAnnotation):
+        _id = fields.Id()
+        name = fields.String(schema.name)
+
+        def __init__(self, _id, name):
+            self._id = _id
+            self.name = name
+
+        class Meta:
+            rdf_type = schema.Book
+
+    data = {
+        "@id": "http://example.com/books/1",
+        "@type": ["http://schema.org/Book"],
+        "http://schema.org/name": "Hitchhikers Guide to the Galaxy",
+    }
+
+    book = Book.schema().load(data)
+
+    assert book._id == "http://example.com/books/1"
+    assert book.name == "Hitchhikers Guide to the Galaxy"
+
+    dumped = Book.schema().dump(book)
+    assert data == dumped
+
+    dumped = book.dump()
+    assert data == dumped
+
+
+def test_annotation_with_default():
+    """Test annotation with default values."""
+    schema = fields.Namespace("http://schema.org/")
+
+    def default_surname():
+        return "Doe"
+
+    class Book(metaclass=JsonLDAnnotation):
+        _id = fields.Id(default="http://example.com/book/1")
+        name = fields.String(schema.name, default=lambda: "Bill")
+        surname = fields.String(schema.surname, default=default_surname)
+
+        class Meta:
+            rdf_type = schema.Book
+
+    b = Book()
+
+    assert b._id == "http://example.com/book/1"
+    assert b.name == "Bill"
+    assert b.surname == "Doe"
+
+    book_dict = b.dump()
+
+    assert "@id" in book_dict
+    assert book_dict["@id"] == b._id
+    assert "http://schema.org/name" in book_dict
+    assert b.name == book_dict["http://schema.org/name"]
+    assert b.surname == book_dict["http://schema.org/surname"]
+
+
+def test_nested_annotation():
+    """Test that nesting works for annotated classes."""
+
+    schema = fields.Namespace("http://schema.org/")
+
+    class Book(metaclass=JsonLDAnnotation):
+        _id = fields.Id()
+        name = fields.String(schema.name)
+
+        def __init__(self, _id, name):
+            self._id = _id
+            self.name = name
+
+        class Meta:
+            rdf_type = schema.Book
+
+    class Author(metaclass=JsonLDAnnotation):
+        _id = fields.Id()
+        name = fields.String(schema.name)
+        books = fields.Nested(schema.author, Book, reverse=True, many=True)
+
+        def __init__(self, _id, name, books):
+            self._id = _id
+            self.name = name
+            self.books = books
+
+        class Meta:
+            rdf_type = schema.Person
+
+    b = Book("http://example.com/book/1", "Le Petit Prince")
+    a = Author("http://example.com/authors/1", "Antoine de Saint-Exupéry", [b])
+
+    author_dict = a.dump()
+
+    assert "@reverse" in author_dict
+    assert "http://schema.org/author" in author_dict["@reverse"]
+    books = author_dict["@reverse"]["http://schema.org/author"]
+    assert len(books) == 1
+    assert books[0]["http://schema.org/name"] == b.name


### PR DESCRIPTION
Adds support for annotations.

Used like:

```
       import datetime.datetime as dt

       from calamus import JsonLDAnnotation
       import calamus.fields as fields

       schema = fields.Namespace("http://schema.org/")

       class User(metaclass=JsonLDAnnotation):
           class Meta:
               rdf_type = schema.Person
           _id = fields.Id()
           birth_date = fields.Date(schema.birthDate, default=dt.now)
           name = fields.String(schema.name, default=lambda: "John")

        user = User()

        # dumping
        User.schema().dump(user)
        # or
        user.dump()

        # loading
        u = User.schema().load({"_id": "http://example.com/user/1", "name": "Bill", "birth_date": "1970-01-01 00:00"})
```

Closes #3 