### PR TITLE
feat: Allow id generation in serialization

### DIFF
--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -73,21 +73,6 @@ class IRIReference(object):
         return str(self).__hash__()
 
 
-class BlankNodeId(object):
-    """ A blank/anonymous node identifier.
-
-    Args:
-        name (str): The name used to construct the blank node id. Default: ``None``.
-                    Will use a UUID if not supplied."""
-
-    def __init__(self, name=None):
-        self.name = name
-
-    def __str__(self):
-        if self.name:
-            return "_:{name}".format(name=self.name)
-        return "_:{uuid}".format(uuid=uuid4)
-
 
 class Namespace(object):
     """Represents a namespace/ontology.
@@ -149,6 +134,32 @@ class Id(_JsonLDField, fields.String):
 
     def __init__(self, *args, **kwargs):
         super().__init__(field_name="@id", *args, **kwargs)
+
+
+class BlankNodeId(fields.String):
+    """ A blank/anonymous node identifier."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        value = super()._serialize(value, attr, obj, **kwargs)
+
+        return f"_:{value}"
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if isinstance(value, str) and value.startswith("_:"):
+            value = value[2:]
+        return super()._deserialize(value, attr, data, **kwargs)
+
+    @property
+    def data_key(self):
+        """Return the (expanded) JsonLD field name."""
+        return "@id"
+
+    @data_key.setter
+    def data_key(self, value):
+        pass
 
 
 class String(_JsonLDField, fields.String):

--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -26,7 +26,6 @@ from marshmallow import class_registry, utils
 from marshmallow.exceptions import ValidationError
 import logging
 import copy
-from uuid import uuid4
 
 import typing
 import types

--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -72,7 +72,6 @@ class IRIReference(object):
         return str(self).__hash__()
 
 
-
 class Namespace(object):
     """Represents a namespace/ontology.
 
@@ -135,8 +134,8 @@ class Id(_JsonLDField, fields.String):
         super().__init__(field_name="@id", *args, **kwargs)
 
 
-class BlankNodeId(fields.String):
-    """ A blank/anonymous node identifier."""
+class BlankNodeId(_JsonLDField, fields.String):
+    """A blank/anonymous node identifier."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -22,6 +22,7 @@ from marshmallow.utils import missing, is_collection, RAISE, set_value, EXCLUDE,
 from marshmallow import post_load
 from collections.abc import Mapping
 from marshmallow.error_store import ErrorStore
+from uuid import uuid4
 
 from pyld import jsonld
 
@@ -41,6 +42,8 @@ class JsonLDSchemaOpts(SchemaOpts):
         - ``rdf_type``: The RDF type(s) for this schema.
         - ``model``: The python type this schema (de-)serializes.
         - ``add_value_types``: Whether to add ``@type`` information to scalar field values.
+        - ``id_generation_strategy``: A callable(dict, obj) that generates an Id on the fly if none is set.
+                                      With dict being the deserialized Json-LD dict and obj being the original object.
 
     """
 
@@ -55,6 +58,7 @@ class JsonLDSchemaOpts(SchemaOpts):
         self.model = getattr(meta, "model", None)
         self.add_value_types = getattr(meta, "add_value_types", False)
 
+        self.id_generation_strategy = getattr(meta, "id_generation_strategy", None)
 
 class JsonLDSchemaMeta(SchemaMeta):
     """Meta-class for a for a JsonLDSchema class."""
@@ -180,6 +184,9 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
                 ret["@reverse"][key] = value
             else:
                 ret[key] = value
+
+        if ("@id" not in ret or not ret["@id"]) and self.opts.id_generation_strategy:
+            ret["@id"] = self.opts.id_generation_strategy(ret, obj)
 
         # add type
         rdf_type = self.opts.rdf_type
@@ -334,6 +341,11 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
                         isinstance(self, s) for s in self._reversed_properties[key]
                     ):
                         continue
+
+                    if key == "@id" and self.opts.id_generation_strategy:
+                        # automatically generated ids don't need to be serialized
+                        continue
+
                     value = data[key]
                     if unknown == INCLUDE:
                         set_value(typing.cast(typing.Dict, ret), key, value)
@@ -411,3 +423,8 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
             )
 
         return instance
+
+
+def blank_node_id_strategy(ret, obj):
+    """id_generation_strategy that creates random blank node ids."""
+    return "_:{id}".format(id=uuid4().hex)

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -36,7 +36,7 @@ _T = typing.TypeVar("_T")
 
 
 def blank_node_id_strategy(ret, obj):
-    """id_generation_strategy that creates random blank node ids."""
+    """``id_generation_strategy`` that creates random blank node ids."""
     return "_:{id}".format(id=uuid4().hex)
 
 
@@ -64,6 +64,7 @@ class JsonLDSchemaOpts(SchemaOpts):
         self.add_value_types = getattr(meta, "add_value_types", False)
 
         self.id_generation_strategy = getattr(meta, "id_generation_strategy", blank_node_id_strategy)
+
 
 class JsonLDSchemaMeta(SchemaMeta):
     """Meta-class for a for a JsonLDSchema class."""

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -35,6 +35,11 @@ from calamus.utils import normalize_id, normalize_type, Proxy
 _T = typing.TypeVar("_T")
 
 
+def blank_node_id_strategy(ret, obj):
+    """id_generation_strategy that creates random blank node ids."""
+    return "_:{id}".format(id=uuid4().hex)
+
+
 class JsonLDSchemaOpts(SchemaOpts):
     """Options class for `JsonLDSchema`.
 
@@ -58,7 +63,7 @@ class JsonLDSchemaOpts(SchemaOpts):
         self.model = getattr(meta, "model", None)
         self.add_value_types = getattr(meta, "add_value_types", False)
 
-        self.id_generation_strategy = getattr(meta, "id_generation_strategy", None)
+        self.id_generation_strategy = getattr(meta, "id_generation_strategy", blank_node_id_strategy)
 
 class JsonLDSchemaMeta(SchemaMeta):
     """Meta-class for a for a JsonLDSchema class."""
@@ -185,7 +190,7 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
             else:
                 ret[key] = value
 
-        if ("@id" not in ret or not ret["@id"]) and self.opts.id_generation_strategy:
+        if "@id" not in ret or not ret["@id"]:
             ret["@id"] = self.opts.id_generation_strategy(ret, obj)
 
         # add type
@@ -423,8 +428,3 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
             )
 
         return instance
-
-
-def blank_node_id_strategy(ret, obj):
-    """id_generation_strategy that creates random blank node ids."""
-    return "_:{id}".format(id=uuid4().hex)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -425,30 +425,30 @@ def test_lazy_proxy_serialization():
     schema = fields.Namespace("https://schema.org/")
 
     class GenreSchema(JsonLDSchema):
-        _id = fields.BlankNodeId()
         name = fields.String(schema.name)
 
         class Meta:
             rdf_type = schema.Genre
             model = Genre
+            id_generation_strategy = blank_node_id_strategy
 
     class BookSchema(JsonLDSchema):
-        _id = fields.BlankNodeId()
         name = fields.String(schema.name)
         genre = fields.Nested(schema.genre, GenreSchema)
 
         class Meta:
             rdf_type = schema.Book
             model = Book
+            id_generation_strategy = blank_node_id_strategy
 
     class AuthorSchema(JsonLDSchema):
-        _id = fields.BlankNodeId()
         name = fields.String(schema.name)
         books = fields.Nested(schema.books, BookSchema, many=True)
 
         class Meta:
             rdf_type = schema.Author
             model = Author
+            id_generation_strategy = blank_node_id_strategy
 
     data = {
         "@type": ["https://schema.org/Author"],
@@ -460,6 +460,7 @@ def test_lazy_proxy_serialization():
             }
         ],
         "https://schema.org/name": "Miguel de Cervantes",
+        "@id": "_:dummyid",
     }
 
     a = AuthorSchema(lazy=True).load(data)


### PR DESCRIPTION
Adds a new Schema Meta option `id_generation_strategy` which can be any `callable(ret, obj) `, with `ret` being the deserialized jsonld dict and `obj` being the original object.

Fixes `BlankNodeField` serialization, which is now meant to turn an id that is present on an object into a blank node id.