### PR TITLE
fix: Fixes serialization when a proxy object is present

### DIFF
--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -341,6 +341,10 @@ class Nested(_JsonLDField, fields.Nested):
 
     def _serialize_single_obj(self, obj, **kwargs):
         """Deserializes a single (possibly flattened) object."""
+        if isinstance(obj, lazy_object_proxy.Proxy):
+            # resolve Proxy object
+            obj = obj.__wrapped__
+
         if type(obj) not in self.schema["to"]:
             ValueError("Type {} not found in field {}.{}".format(type(obj), type(self.parent), self.name))
 
@@ -352,6 +356,9 @@ class Nested(_JsonLDField, fields.Nested):
         """Deserialize a nested field with one or many values."""
         if nested_obj is None:
             return None
+        if isinstance(nested_obj, lazy_object_proxy.Proxy):
+            # resolve Proxy object
+            nested_obj = nested_obj.__wrapped__
         many = self.many or many
         if many:
             result = []

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -22,6 +22,7 @@ from marshmallow.utils import missing, is_collection, RAISE, set_value, EXCLUDE,
 from marshmallow import post_load
 from collections.abc import Mapping
 from marshmallow.error_store import ErrorStore
+import lazy_object_proxy
 
 from pyld import jsonld
 
@@ -153,6 +154,11 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
         """Serialize ``obj`` to jsonld."""
         if many and obj is not None:
             return [self._serialize(d, many=False) for d in typing.cast(typing.Iterable[_T], obj)]
+
+        if isinstance(obj, lazy_object_proxy.Proxy):
+            # resolve Proxy object
+            obj = obj.__wrapped__
+
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
             value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -421,7 +421,7 @@ def test_alternative_date_format_deserialization(formats, value, deserialized_va
 
 def test_lazy_deserialization():
     """Tests that lazy deserialization works."""
-    import lazy_object_proxy
+    from calamus.utils import Proxy
 
     class Genre:
         def __init__(self, name):
@@ -488,7 +488,7 @@ def test_lazy_deserialization():
     assert a.name == "Miguel de Cervantes"
     book = a.books[0]
 
-    assert isinstance(book, lazy_object_proxy.Proxy)
+    assert isinstance(book, Proxy)
     assert " wrapping " not in repr(book)  # make sure proxy is not evaluated yet
 
     assert book.name == "Don Quixote"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -400,7 +400,7 @@ def test_iri_field_serialization():
 
 def test_lazy_proxy_serialization():
     """Tests that lazy deserialization works."""
-    import lazy_object_proxy
+    from calamus.utils import Proxy
 
     class Genre:
         def __init__(self, name):
@@ -467,8 +467,20 @@ def test_lazy_proxy_serialization():
     assert a.name == "Miguel de Cervantes"
     book = a.books[0]
 
-    assert isinstance(book, lazy_object_proxy.Proxy)
+    assert isinstance(book, Proxy)
 
     author = AuthorSchema().dump(a)
 
+    assert not book.__proxy_initialized__
+
     assert author.keys() == data.keys()
+
+    original_book = BookSchema(flattened=False).dump(book)
+    assert isinstance(original_book, dict)
+    assert not book.__proxy_initialized__
+
+    flat_book = BookSchema(flattened=True).dump(book)
+
+    assert isinstance(flat_book, list)
+    assert len(flat_book) == 2
+    assert book.__proxy_initialized__


### PR DESCRIPTION
If an object attribute is a proxy object (from lazy loading), nested field serialization fails due to the type of the proxy object not matching the expected type of the nested field