### PR TITLE
docs: add required imports to minimal example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,9 @@ Declare schemes
 ---------------
 You can declare a schema for serialization like
 ::
-
+    from calamus import fields
+    from calamus.schema import JsonLDSchema
+    
     schema = fields.Namespace("http://schema.org/")
 
     class BookSchema(JsonLDSchema):

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ Declare schemes
 ---------------
 You can declare a schema for serialization like
 ::
+
     from calamus import fields
     from calamus.schema import JsonLDSchema
     


### PR DESCRIPTION
The basic example in the readme doesn't work because it's missing imports. It's nice to have it a copy-paste sort of affair. 