### PR TITLE
fix: fix IRI serialization when empty

### DIFF
--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -198,7 +198,8 @@ class IRI(String):
 
     def _serialize(self, value, attr, obj, **kwargs):
         value = super()._serialize(value, attr, obj, **kwargs)
-        return {"@id": value}
+        if value:
+            return {"@id": value}
 
     def _deserialize(self, value, attr, data, **kwargs):
         if "@id" in value:

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -252,7 +252,7 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
             for d in data:
                 self._all_objects[d["@id"]] = d
 
-                if self._compare_ids(d["@type"], self.opts.rdf_type):
+                if "@type" in d and self._compare_ids(d["@type"], self.opts.rdf_type):
                     new_data.append(d)
 
             data = new_data

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -328,7 +328,7 @@ def test_iri_field_deserialization():
 
     class ASchema(JsonLDSchema):
         _id = fields.Id()
-        url = fields.IRI(schema.url)
+        url = fields.IRI(schema.url, allow_none=True)
 
         class Meta:
             rdf_type = schema.A
@@ -343,6 +343,16 @@ def test_iri_field_deserialization():
     a = ASchema().load(data)
 
     assert a.url == "http://datascience.ch"
+
+    data = {
+        "@id": "http://example.com/1",
+        "@type": ["http://schema.org/A"],
+        "http://schema.org/url": None,
+    }
+
+    a = ASchema().load(data)
+
+    assert a.url == None
 
 
 @pytest.mark.parametrize("value", [["1"], ["1", "2"]])

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -397,6 +397,13 @@ def test_iri_field_serialization():
     assert "@id" in jsonld["http://schema.org/url"]
     assert jsonld["http://schema.org/url"]["@id"] == "http://datascience.ch"
 
+    b = A("http://example.com/2", None)
+
+    jsonld = ASchema().dump(b)
+
+    assert "http://schema.org/url" in jsonld
+    assert jsonld["http://schema.org/url"] == None
+
 
 def test_lazy_proxy_serialization():
     """Tests that lazy deserialization works."""


### PR DESCRIPTION
return
```
"field": None
```

not
```
"field: {
    "@id": None
}
```
when serializing a None IRI