### PR TITLE
fix: improve performance of calamus.utils import using deferred execution

### DIFF
--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -17,22 +17,19 @@
 # limitations under the License.
 """Marshmallow fields for use with JSON-LD."""
 
+import copy
+import logging
+import types
+import typing
 from functools import total_ordering
 
 import marshmallow.fields as fields
-from marshmallow.base import SchemaABC
 from marshmallow import class_registry, utils
+from marshmallow.base import SchemaABC
 from marshmallow.exceptions import ValidationError
-import logging
-import copy
-
-import rdflib
-
-import typing
-import types
 
 from calamus.schema import JsonLDSchema
-from calamus.utils import normalize_type, normalize_value, ONTOLOGY_QUERY, Proxy
+from calamus.utils import ONTOLOGY_QUERY, Proxy, normalize_type, normalize_value
 
 logger = logging.getLogger("calamus")
 
@@ -87,14 +84,18 @@ class Namespace(object):
         self.ontology = None
 
         if ontology:
-            g = rdflib.Graph()
+            from rdflib.graph import Graph
+
+            g = Graph()
             self.ontology = g.parse(ontology)
 
     def __getattr__(self, name):
         reference = IRIReference(self, name)
 
         if self.ontology:
-            p = rdflib.URIRef(str(reference))
+            from rdflib.term import URIRef
+
+            p = URIRef(str(reference))
             qres = self.ontology.query(ONTOLOGY_QUERY, initBindings={"property": p})
             if not next(iter(qres), False):
                 raise ValueError(f"Property {name} does not exist in namespace {self.namespace}")

--- a/calamus/schema.py
+++ b/calamus/schema.py
@@ -17,21 +17,19 @@
 # limitations under the License.
 """Marshmallow schema implementation that supports JSON-LD."""
 
-from marshmallow.schema import Schema, SchemaMeta, SchemaOpts
-from marshmallow.utils import missing, is_collection, RAISE, set_value, EXCLUDE, INCLUDE
-from marshmallow import post_load
-from collections.abc import Mapping
-from marshmallow.error_store import ErrorStore
-from rdflib.plugins.sparql import prepareQuery
-from uuid import uuid4
-import rdflib
-from pyld import jsonld
-
 import inspect
 import typing
+from collections.abc import Mapping
 from functools import lru_cache
+from uuid import uuid4
 
-from calamus.utils import normalize_id, normalize_type, Proxy, validate_field_properties
+from marshmallow import post_load
+from marshmallow.error_store import ErrorStore
+from marshmallow.schema import Schema, SchemaMeta, SchemaOpts
+from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value
+from pyld import jsonld
+
+from calamus.utils import Proxy, normalize_id, normalize_type, validate_field_properties
 
 _T = typing.TypeVar("_T")
 
@@ -388,11 +386,13 @@ class JsonLDSchema(Schema, metaclass=JsonLDSchemaMeta):
             return_valid_data (bool): Whether to delete invalid properties to return only valid data or else
                 returns a dict containing valid and invalid properties, Default: ``False``
         """
+        from rdflib.graph import Graph
+        from rdflib.plugins.sparql import prepareQuery
 
         if isinstance(data, self.Meta.model) or all(isinstance(s, self.Meta.model) for s in data):
             data = self.dump(data)
 
-        g = rdflib.Graph()
+        g = Graph()
         if not isinstance(ontology, list):
             ontology = [ontology]
 


### PR DESCRIPTION
Related to https://github.com/SwissDataScienceCenter/renku-python/issues/2411

`prepareQuery` is super slow and takes almost 1 second by itself.

the other big waste of time is importing rdflib (~0.45s).

Also ran isort.

Before:
```
time python -c "import calamus.utils"

real    0m1.354s
user    0m1.297s
sys     0m0.057s
```

After:
```
$ time python -c "import calamus.utils"

real    0m0.062s
user    0m0.056s
sys     0m0.008s
```