### PR TITLE
chore: fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ build:
     image: latest
 
 python:
-    version: 3.6
+    version: 3.8
     pip_install: true
     extra_requirements:
         - docs


### PR DESCRIPTION
Since we use rdflib > 6 and that doesn't work on python 3.6, updates python version to fix docs build.