### PR TITLE
Fix IRI serialization

### DIFF
--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -206,10 +206,7 @@ class IRI(String):
 
     def _serialize(self, value, attr, obj, **kwargs):
         if self.parent.opts.add_value_types or self.add_value_types:
-            return {
-                "@value": value,
-                "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
-            }
+            return {"@id": value}
 
         value = super()._serialize(value, attr, obj, **kwargs)
         if value:

--- a/calamus/fields.py
+++ b/calamus/fields.py
@@ -205,6 +205,12 @@ class IRI(String):
         super().__init__(*args, **kwargs)
 
     def _serialize(self, value, attr, obj, **kwargs):
+        if self.parent.opts.add_value_types or self.add_value_types:
+            return {
+                "@value": value,
+                "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+            }
+
         value = super()._serialize(value, attr, obj, **kwargs)
         if value:
             return {"@id": value}


### PR DESCRIPTION
In calamus 0.4.0, IRI are serialized as `xsd:string` when using `add_value_types=True`. They should instead be serialized as `xsd:anyURI`. This PR addresses the issue.


Example:

```python
from dataclasses import dataclass
from typing import Optional

from calamus.schema import JsonLDSchema
from calamus import fields
from rdflib.namespace import Namespace

SDO = Namespace("http://schema.org/")

@dataclass
class Organization:
    """See http//schema.org/Organization"""

    _id: str
    logo: Optional[str] = None

class OrganizationSchema(JsonLDSchema):
    _id = fields.Id()
    logo = fields.IRI(SDO.logo)

    class Meta:
        rdf_type = SDO.Organization
        model = Organization
        add_value_types = True


sdsc = Organization('https://datascience.ch', logo='https://datascience.ch/wp-content/uploads/2019/04/logo_SDSC-300x82.png')

print(OrganizationSchema().dumps(sdsc, indent=2))

```

Output before the PR:

```json
{
  "@id": "https://datascience.ch",
  "http://schema.org/logo": {
    "@id": {
      "@value": "https://datascience.ch/wp-content/uploads/2019/04/logo_SDSC-300x82.png",
      "@type": "http://www.w3.org/2001/XMLSchema#string"
    }
  },
  "@type": [
    "http://schema.org/Organization"
  ]
}
```

Output after the PR:

```json
{
  "@id": "https://datascience.ch",
  "http://schema.org/logo": {
    "@value": "https://datascience.ch/wp-content/uploads/2019/04/logo_SDSC-300x82.png",
    "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
  },
  "@type": [
    "http://schema.org/Organization"
  ]
}
```
